### PR TITLE
Stop DMA throttling data flow

### DIFF
--- a/boards/ZCU111/rfsoc_sam/notebooks/data_inspector.py
+++ b/boards/ZCU111/rfsoc_sam/notebooks/data_inspector.py
@@ -19,8 +19,8 @@ class DataInspector(DefaultHierarchy):
         """Get a single buffer of FFT data from the pulse shaped signal
         """
         self.data_inspector.reset = 0
-        self.data_inspector.transfer = 1
         self.axi_dma_inspector.recvchannel.transfer(self.buf_data)
+        self.data_inspector.transfer = 1
         self.axi_dma_inspector.recvchannel.wait()
         self.data_inspector.transfer = 0
         self.data_inspector.reset = 1

--- a/rfsoc_sam/data_inspector.py
+++ b/rfsoc_sam/data_inspector.py
@@ -19,8 +19,8 @@ class DataInspector(DefaultHierarchy):
         """Get a single buffer of FFT data from the pulse shaped signal
         """
         self.data_inspector.reset = 0
-        self.data_inspector.transfer = 1
         self.axi_dma_inspector.recvchannel.transfer(self.buf_data)
+        self.data_inspector.transfer = 1
         self.axi_dma_inspector.recvchannel.wait()
         self.data_inspector.transfer = 0
         self.data_inspector.reset = 1


### PR DESCRIPTION
The DMA needs to be aware of incoming data before it arrives to prevent backpressure.